### PR TITLE
Fixes on cut command run

### DIFF
--- a/slicing_copy.lua
+++ b/slicing_copy.lua
@@ -123,11 +123,11 @@ local function toggle_mark()
             shift, endpos = endpos, shift
         elseif shift == endpos then
             osd("Cut fragment is empty")
-        else
-            cut_pos = nil
-            osd(string.format("Cut fragment: %s-%s", timestamp(shift), timestamp(endpos)))
-            cut(shift, endpos)
+            return
         end
+        cut_pos = nil
+        osd(string.format("Cut fragment: %s-%s", timestamp(shift), timestamp(endpos)))
+        cut(shift, endpos)
     else
         cut_pos = pos
         osd(string.format("Marked %s as start position", timestamp(pos)))

--- a/slicing_copy.lua
+++ b/slicing_copy.lua
@@ -16,12 +16,14 @@ local o = {
     acodec = "copy",
 }
 
-Command = { name = "", args = {""} }
+Command = { }
 
 function Command:new(name)
     local o = {}
     setmetatable(o, self)
     self.__index = self
+    o.name = ""
+    o.args = { "" }
     if name then
         o.name = name
         o.args[1] = name


### PR DESCRIPTION
- Fix cut command that was launched with wrong arguments if it was already launched before reopening mpv
- Fix cut command that would not run if end position was before start position