### PR TITLE
Correctly zero-pad seconds < 10 in timestamps

### DIFF
--- a/slicing_copy.lua
+++ b/slicing_copy.lua
@@ -73,7 +73,7 @@ local function timestamp(duration)
     local hours = math.floor(duration / 3600)
     local minutes = math.floor(duration % 3600 / 60)
     local seconds = duration % 60
-    return string.format("%02d:%02d:%02.03f", hours, minutes, seconds)
+    return string.format("%02d:%02d:%06.3f", hours, minutes, seconds)
 end
 
 local function osd(str)


### PR DESCRIPTION
Somewhat unintuitively, the `X` in `%X.Yf` is meant to specify the desired width of the entire formatted variable, not just the integer part. This patch takes this into account so that timestamps containing a seconds value less than 10 are correctly zero-padded.